### PR TITLE
検索設定画面の追加

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,6 +14,7 @@
   --submit-button: light-dark(#40adfa, #12334a);
   --submit-button-hover: light-dark(#40adfa, #1c4f73);
   --button-color: light-dark(#e9eef1, #12334a);
+  --button-border: light-dark(#ccd0d6, #1c4f73);
   --button-text-color: light-dark(#0a1c29, #c3dcef);
   --button-text-color-hover: light-dark(#1c4f73, #f7fbfd);
   --save-button-text-color: light-dark(#ffffff, #0a1c29);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,8 +6,10 @@ import ButtonArea from "components/ButtonArea/ButtonArea";
 export default function Home() {
   return (
     <div className="flex flex-col w-full h-full min-h-[100dvh]">
-      <main className="flex flex-col items-center justify-center mx-auto p-0 w-full flex-1 overflow-hidden">
+      <div className="flex items-end justify-center w-full max-md:h-[calc(100dvh/3.5)] h-[calc(100dvh/3)]">
         <Logo />
+      </div>
+      <main className="flex flex-col items-center justify-start mx-auto p-0 w-full flex-1 overflow-hidden">
         <div className="flex flex-col items-center justify-center mt-8 w-full max-w-2xl">
           <SearchBar />
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import ButtonArea from "components/ButtonArea/ButtonArea";
 
 export default function Home() {
   return (
-    <div className="flex flex-col w-full h-[100dvh]">
+    <div className="flex flex-col w-full h-full min-h-[100dvh]">
       <main className="flex flex-col items-center justify-center mx-auto p-0 w-full flex-1 overflow-hidden">
         <Logo />
         <div className="flex flex-col items-center justify-center mt-8 w-full max-w-2xl">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -17,7 +17,7 @@ export default function Home() {
         <ButtonSettingsArea />
         <SelectorSettingsArea />
       </main>
-      <footer className="flex items-center justify-center w-full h-16">
+      <footer className="flex items-center justify-center w-full h-20">
         <SaveButton />
       </footer>
     </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,18 +2,22 @@ import Logo from "components/Logo";
 import SaveButton from "components/Settings/SaveButton";
 import SearchBar from "components/SearchArea/SearchBar";
 import ButtonSettingsArea from "components/Settings/ButtonSettingsArea";
+import SelectorSettingsArea from "components/Settings/SelectorSettingsArea";
 
 export default function Home() {
   return (
     <div className="flex flex-col w-full h-full min-h-[100dvh]">
-      <main className="flex flex-col items-center justify-center mx-auto p-0 w-full flex-1 overflow-hidden">
+      <div className="flex items-end justify-center w-full max-md:h-[calc(100dvh/3.5)] h-[calc(100dvh/3)]">
         <Logo />
+      </div>
+      <main className="flex flex-col items-center justify-center mx-auto p-0 w-full flex-1 overflow-hidden">
         <div className="flex flex-col items-center justify-center mt-8 w-full max-w-2xl">
           <SearchBar />
         </div>
         <ButtonSettingsArea />
+        <SelectorSettingsArea />
       </main>
-      <footer className="absolute bottom-0 flex items-center justify-center w-full h-16">
+      <footer className="flex items-center justify-center w-full h-16">
         <SaveButton />
       </footer>
     </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,7 +1,7 @@
 import Logo from "components/Logo";
 import SaveButton from "components/Settings/SaveButton";
 import SearchBar from "components/SearchArea/SearchBar";
-import SettingsArea from "components/Settings/SettingsArea";
+import ButtonSettingsArea from "components/Settings/ButtonSettingsArea";
 
 export default function Home() {
   return (
@@ -11,7 +11,7 @@ export default function Home() {
         <div className="flex flex-col items-center justify-center mt-8 w-full max-w-2xl">
           <SearchBar />
         </div>
-        <SettingsArea />
+        <ButtonSettingsArea />
       </main>
       <footer className="absolute bottom-0 flex items-center justify-center w-full h-16">
         <SaveButton />

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -5,7 +5,7 @@ import ButtonSettingsArea from "components/Settings/ButtonSettingsArea";
 
 export default function Home() {
   return (
-    <div className="flex flex-col w-full h-[100dvh]">
+    <div className="flex flex-col w-full h-full min-h-[100dvh]">
       <main className="flex flex-col items-center justify-center mx-auto p-0 w-full flex-1 overflow-hidden">
         <Logo />
         <div className="flex flex-col items-center justify-center mt-8 w-full max-w-2xl">

--- a/src/components/ButtonArea/ButtonArea.tsx
+++ b/src/components/ButtonArea/ButtonArea.tsx
@@ -62,7 +62,7 @@ export default function ButtonArea() {
     <div className="flex flex-col justify-center mx-auto pt-4 pb-12 max-md:overflow-x-scroll max-md:w-full">
       {activeCategories.map((category, index) => (
         <div key={index} className="flex justify-start mt-3 max-md:ml-5">
-          <div className="flex justify-center items-center w-[2.7em] h-[2.7em] mr-2 text-base font-bold text-(--button-text-color) bg-(--button-color) rounded-full flex-shrink-0">
+          <div className="flex justify-center items-center w-[2.7em] h-[2.7em] mr-2 text-base font-bold text-(--button-text-color) bg-(--button-color) border-1 border-(--button-color) rounded-full flex-shrink-0">
             <span className={`${categoryIconMap[category.name] || "mdi:folder-outline"} w-5 h-5`}></span>
           </div>
           <div className="flex justify-center items-center">

--- a/src/components/ButtonArea/ButtonArea.tsx
+++ b/src/components/ButtonArea/ButtonArea.tsx
@@ -59,7 +59,7 @@ export default function ButtonArea() {
   }
 
   return (
-    <div className="flex flex-col justify-center mx-auto my-4 mb-8 max-md:overflow-x-scroll max-md:w-full">
+    <div className="flex flex-col justify-center mx-auto pt-4 pb-12 max-md:overflow-x-scroll max-md:w-full">
       {activeCategories.map((category, index) => (
         <div key={index} className="flex justify-start mt-3 max-md:ml-5">
           <div className="flex justify-center items-center w-[2.7em] h-[2.7em] mr-2 text-base font-bold text-(--button-text-color) bg-(--button-color) rounded-full flex-shrink-0">

--- a/src/components/ButtonArea/ButtonComponents/LinkButton.tsx
+++ b/src/components/ButtonArea/ButtonComponents/LinkButton.tsx
@@ -38,7 +38,7 @@ export const LinkButton: React.FC<DomainItem> = ({
   return (
     <button
       onClick={handleClick}
-      className="inline-flex items-center justify-center w-auto min-w-18 h-auto bg-(--button-color) text-(--button-text-color) no-underline py-2.5 px-4 mr-2 rounded-md flex-shrink-0 transition-colors duration-200 cursor-pointer hover:text-(--button-text-color-hover)"
+      className="inline-flex items-center justify-center border-1 border-(--button-border) w-auto min-w-18 h-auto bg-(--button-color) text-(--button-text-color) no-underline py-2 px-3.5 mr-2 rounded-md flex-shrink-0 transition-colors duration-200 cursor-pointer hover:text-(--button-text-color-hover)"
       type="button"
     >
       {name}

--- a/src/components/ButtonArea/ButtonComponents/LinkButton.tsx
+++ b/src/components/ButtonArea/ButtonComponents/LinkButton.tsx
@@ -4,6 +4,7 @@ import { useSearch } from "../../SearchArea/SearchContext";
 import { useCallback } from "react";
 import { DomainItem } from 'types';
 import { generateSearchUrl } from 'utils/searchUrlGenerator';
+import { useTabOpenSettings } from 'hooks/useTabOpenSettings';
 
 export const LinkButton: React.FC<DomainItem> = ({
   type,
@@ -16,6 +17,7 @@ export const LinkButton: React.FC<DomainItem> = ({
   queryAlt = "",
 }) => {
   const { wordInput } = useSearch();
+  const { tabOpenType } = useTabOpenSettings();
 
   const handleClick = useCallback(() => {
     const url = generateSearchUrl(wordInput, {
@@ -29,9 +31,9 @@ export const LinkButton: React.FC<DomainItem> = ({
       queryAlt,
     });
     if (url) {
-      window.open(url, "_blank", "noopener,noreferrer");
+      window.open(url, tabOpenType === 'new' ? '_blank' : '_self', "noopener,noreferrer");
     }
-  }, [type, name, domain, subDomain, directory, queryBefore, queryAfter, queryAlt, wordInput]);
+  }, [type, name, domain, subDomain, directory, queryBefore, queryAfter, queryAlt, wordInput, tabOpenType]);
 
   return (
     <button

--- a/src/components/ButtonArea/ButtonComponents/LinkButton.tsx
+++ b/src/components/ButtonArea/ButtonComponents/LinkButton.tsx
@@ -3,6 +3,7 @@
 import { useSearch } from "../../SearchArea/SearchContext";
 import { useCallback } from "react";
 import { DomainItem } from 'types';
+import { generateSearchUrl } from 'utils/searchUrlGenerator';
 
 export const LinkButton: React.FC<DomainItem> = ({
   type,
@@ -16,89 +17,21 @@ export const LinkButton: React.FC<DomainItem> = ({
 }) => {
   const { wordInput } = useSearch();
 
-  const wordInputEncoded = encodeURIComponent(
-    wordInput.replace(/^[\p{C}\p{Z}]+|[\p{C}\p{Z}]+$/gu, "")
-  );
-  const wordInputEncodedHash = encodeURIComponent(
-    wordInput.replace(/^#+|[\p{C}\p{Z}]/gu, "")
-  );
-  const wordInputEncodedAt = encodeURIComponent(
-    wordInput.replace(/^@+|[\p{C}\p{Z}]/gu, "")
-  );
-
-  const searchQuery1 = wordInput
-    ? `https://${domain}${queryBefore}${wordInputEncoded}`
-    : `https://${domain}`;
-
-  const searchQuery2 = wordInput
-    ? `https://${domain}${queryBefore}${wordInputEncoded}${queryAfter}`
-    : `https://${domain}${directory}`;
-
-  const searchQuery3 = wordInput
-    ? `https://${domain}${directory}${queryBefore}${wordInputEncoded}${queryAfter}`
-    : `https://${domain}${directory}`;
-
-  const searchQuery4 = wordInput
-    ? `https://${subDomain}${domain}${queryBefore}${wordInputEncoded}`
-    : `https://${domain}`;
-
-  const searchQuery5 = wordInput
-    ? `https://${domain}${queryBefore}${wordInputEncoded}${queryAfter}`
-    : `https://${domain}`;
-
-  const searchQuery6 = useCallback(() => {
-    if (wordInput.match(/^#/)) {
-      return `https://${domain}${queryAlt}${wordInputEncodedHash}`;
-    } else if (wordInput.match(/^@/)) {
-      return `https://${domain}${wordInputEncodedAt}`;
-    } else if (wordInput) {
-      return `https://${domain}${queryBefore}${wordInputEncoded}`;
-    } else {
-      return `https://${domain}`;
-    }
-  }, [domain, queryAlt, queryBefore, wordInputEncodedHash, wordInputEncodedAt, wordInputEncoded, wordInput]);
-
-  // pixiv用の検索クエリ設定
-  const searchQuery7 = useCallback(() => {
-    if (wordInput.match(/^#/)) {
-      return `https://${domain}${queryBefore}${wordInputEncodedHash}`;
-    } else if (wordInput.match(/^@/)) {
-      return `https://${domain}${queryAlt}${wordInputEncodedAt}`;
-    } else if (wordInput) {
-      return `https://${domain}${queryBefore}${wordInputEncoded}${queryAfter}`;
-    } else {
-      return `https://${domain}`;
-    }
-  }, [domain, queryAlt, queryBefore, queryAfter, wordInputEncodedHash, wordInputEncodedAt, wordInputEncoded, wordInput]);
-
-  const searchUrl = useCallback(() => {
-    switch (true) {
-      case type === 1:
-        return searchQuery1;
-      case type === 2:
-        return searchQuery2;
-      case type === 3:
-        return searchQuery3;
-      case type === 4:
-        return searchQuery4;
-      case type === 5:
-        return searchQuery5;
-      case type === 6:
-        return searchQuery6();
-        case type === 7:
-        return searchQuery7();
-      default:
-        console.log("No search query");
-        return "";
-    }
-  }, [type, searchQuery1, searchQuery2, searchQuery3, searchQuery4, searchQuery5, searchQuery6, searchQuery7]);
-
   const handleClick = useCallback(() => {
-    const url = searchUrl();
+    const url = generateSearchUrl(wordInput, {
+      type,
+      name,
+      domain,
+      subDomain,
+      directory,
+      queryBefore,
+      queryAfter,
+      queryAlt,
+    });
     if (url) {
       window.open(url, "_blank", "noopener,noreferrer");
     }
-  }, [searchUrl]);
+  }, [type, name, domain, subDomain, directory, queryBefore, queryAfter, queryAlt, wordInput]);
 
   return (
     <button

--- a/src/components/SearchArea/SearchComponents/SubmitButton.tsx
+++ b/src/components/SearchArea/SearchComponents/SubmitButton.tsx
@@ -55,7 +55,7 @@ export default function SubmitButton({ wordInput }: SearchInputProps) {
   return (
     <button
       type="button"
-      className="h-full w-auto flex justify-center items-center bg-(--submit-button) border-none rounded-r-md px-3 transition-opacity duration-200 cursor-pointer flex-shrink-0 hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-(--submit-button)"
+      className="h-full min-h-[2.7em] w-auto flex justify-center items-center bg-(--submit-button) border-none rounded-r-md px-3 transition-opacity duration-200 cursor-pointer flex-shrink-0 hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-(--submit-button)"
       onClick={handleClick}
       aria-label="検索実行"
     >

--- a/src/components/SearchArea/SearchComponents/useDefaultSearch.ts
+++ b/src/components/SearchArea/SearchComponents/useDefaultSearch.ts
@@ -5,7 +5,7 @@ export const useDefaultSearch = () => {
     );
     const url = searchWord
       ? `https://www.google.co.jp/search?q=${encodedQuery}`
-      : "https://www.google.co,jp/";
+      : "https://www.google.co.jp/";
 
     window.open(url, '_blank');
   };

--- a/src/components/SearchArea/SearchComponents/useDefaultSearch.ts
+++ b/src/components/SearchArea/SearchComponents/useDefaultSearch.ts
@@ -1,8 +1,10 @@
 import { useDefaultSearchSettings } from 'hooks/useDefaultSearchSettings';
+import { useTabOpenSettings } from 'hooks/useTabOpenSettings';
 import { generateSearchUrl } from 'utils/searchUrlGenerator';
 
 export const useDefaultSearch = () => {
   const { defaultSearch } = useDefaultSearchSettings();
+  const { tabOpenType } = useTabOpenSettings();
 
   const performSearch = (searchWord: string) => {
     if (!defaultSearch) {
@@ -13,12 +15,12 @@ export const useDefaultSearch = () => {
       const url = searchWord
         ? `https://www.google.co.jp/search?q=${encodedQuery}`
         : "https://www.google.co.jp/";
-      window.open(url, '_blank');
+      window.open(url, tabOpenType === 'new' ? '_blank' : '_self');
       return;
     }
 
     const searchUrl = generateSearchUrl(searchWord, defaultSearch);
-    window.open(searchUrl, '_blank');
+    window.open(searchUrl, tabOpenType === 'new' ? '_blank' : '_self');
   };
 
   return { performSearch };

--- a/src/components/SearchArea/SearchComponents/useDefaultSearch.ts
+++ b/src/components/SearchArea/SearchComponents/useDefaultSearch.ts
@@ -1,13 +1,24 @@
-export const useDefaultSearch = () => {
-  const performSearch = (searchWord: string) => {
-    const encodedQuery = encodeURIComponent(
-      searchWord.replace(/^[\p{C}\p{Z}]+|[\p{C}\p{Z}]+$/gu, "")
-    );
-    const url = searchWord
-      ? `https://www.google.co.jp/search?q=${encodedQuery}`
-      : "https://www.google.co.jp/";
+import { useDefaultSearchSettings } from 'hooks/useDefaultSearchSettings';
+import { generateSearchUrl } from 'utils/searchUrlGenerator';
 
-    window.open(url, '_blank');
+export const useDefaultSearch = () => {
+  const { defaultSearch } = useDefaultSearchSettings();
+
+  const performSearch = (searchWord: string) => {
+    if (!defaultSearch) {
+      // デフォルト検索サイトが設定されていない場合はGoogle検索を使用
+      const encodedQuery = encodeURIComponent(
+        searchWord.replace(/^[\p{C}\p{Z}]+|[\p{C}\p{Z}]+$/gu, "")
+      );
+      const url = searchWord
+        ? `https://www.google.co.jp/search?q=${encodedQuery}`
+        : "https://www.google.co.jp/";
+      window.open(url, '_blank');
+      return;
+    }
+
+    const searchUrl = generateSearchUrl(searchWord, defaultSearch);
+    window.open(searchUrl, '_blank');
   };
 
   return { performSearch };

--- a/src/components/Settings/ButtonSettingsArea.tsx
+++ b/src/components/Settings/ButtonSettingsArea.tsx
@@ -67,7 +67,7 @@ function SortableButton({ button, category, onToggle }: {
       <button
         onClick={handleCloseClick}
         className="absolute cursor-pointer -top-2 -right-2 w-5 h-5 flex items-center justify-center bg-(--search-bar-bg) border-solid border-2 border-(--search-bar-border-hover) text-(--button-text-color) rounded-full group-hover:opacity-100 transition-opacity duration-200"
-        title={`${button.name}を無効にする`}
+        title={`${button.name}を非表示にする`}
         type="button"
       >
         <span className="icon-[mdi--close] w-3 h-3"></span>
@@ -180,7 +180,7 @@ export default function ButtonSettingsArea() {
                 <button
                   onClick={() => toggleExpanded(categoryIndex)}
                   className="ml-2 flex items-center justify-center w-[2.7em] h-[2.7em] text-base font-bold text-(--button-text-color) bg-(--button-color) rounded-full flex-shrink-0 border-solid border-2 border-(--search-bar-border-hover) cursor-pointer"
-                  title={isExpanded ? "無効のボタンを隠す" : "無効のボタンを表示"}
+                  title={isExpanded ? "非表示のボタンを閉じる" : "非表示のボタンを表示"}
                 >
                   {isExpanded ? 
                     <span className={`icon-[mdi--check] w-5 h-5`}></span>

--- a/src/components/Settings/ButtonSettingsArea.tsx
+++ b/src/components/Settings/ButtonSettingsArea.tsx
@@ -110,17 +110,6 @@ export default function ButtonSettingsArea() {
 
   const handleToggleButton = (buttonId: string) => {
     toggleButton(buttonId);
-    // ボタンが無効化された場合、該当するカテゴリを展開状態にする
-    const categoryIndex = categories.findIndex(category =>
-      category.list.some(button => button.id === buttonId)
-    );
-    if (categoryIndex !== -1) {
-      setExpandedCategories(prev => {
-        const newSet = new Set(prev);
-        newSet.add(categoryIndex);
-        return newSet;
-      });
-    }
   };
 
   if (loading) {

--- a/src/components/Settings/ButtonSettingsArea.tsx
+++ b/src/components/Settings/ButtonSettingsArea.tsx
@@ -55,10 +55,11 @@ function SortableButton({ button, category, onToggle }: {
 
   return (
     <div ref={setNodeRef} style={style} className="relative group touch-none">
-      <div {...attributes} {...listeners} className="cursor-move">
+      <div {...attributes} {...listeners}>
         <button
-          className="select-none min-w-18 px-3 py-2 rounded-md whitespace-nowrap bg-(--button-color) text-(--button-text-color) border-2 border-solid border-(--search-bar-border-hover)"
+          className="select-none cursor-move min-w-18 px-3 py-2 rounded-md whitespace-nowrap bg-(--button-color) text-(--button-text-color) border-2 border-solid border-(--search-bar-border-hover)"
           disabled={!category.isActive}
+          type="button"
         >
           {button.name}
         </button>
@@ -67,6 +68,7 @@ function SortableButton({ button, category, onToggle }: {
         onClick={handleCloseClick}
         className="absolute cursor-pointer -top-2 -right-2 w-5 h-5 flex items-center justify-center bg-(--search-bar-bg) border-solid border-2 border-(--search-bar-border-hover) text-(--button-text-color) rounded-full group-hover:opacity-100 transition-opacity duration-200"
         title={`${button.name}を無効にする`}
+        type="button"
       >
         <span className="icon-[mdi--close] w-3 h-3"></span>
       </button>
@@ -123,7 +125,7 @@ export default function ButtonSettingsArea() {
 
   if (loading) {
     return (
-      <div className="flex justify-center items-center my-8">読み込み中...</div>
+      <div className="flex justify-center items-center my-8 max-md:h-[calc(100dvh/2)] h-[calc(100dvh/3)]">読み込み中...</div>
     );
   }
 

--- a/src/components/Settings/ButtonSettingsArea.tsx
+++ b/src/components/Settings/ButtonSettingsArea.tsx
@@ -57,7 +57,7 @@ function SortableButton({ button, category, onToggle }: {
     <div ref={setNodeRef} style={style} className="relative group touch-none">
       <div {...attributes} {...listeners}>
         <button
-          className="select-none cursor-move min-w-18 px-3 py-2 rounded-md whitespace-nowrap bg-(--button-color) text-(--button-text-color) border-2 border-solid border-(--search-bar-border-hover)"
+          className="select-none cursor-move min-w-18 py-2 px-3.5 rounded-md whitespace-nowrap bg-(--button-color) text-(--button-text-color) border-3 border-solid border-(--button-border)"
           disabled={!category.isActive}
           type="button"
         >
@@ -66,7 +66,7 @@ function SortableButton({ button, category, onToggle }: {
       </div>
       <button
         onClick={handleCloseClick}
-        className="absolute cursor-pointer -top-2 -right-2 w-5 h-5 flex items-center justify-center bg-(--search-bar-bg) border-solid border-2 border-(--search-bar-border-hover) text-(--button-text-color) rounded-full group-hover:opacity-100 transition-opacity duration-200"
+        className="absolute cursor-pointer -top-2 -right-2 w-5 h-5 flex items-center justify-center bg-(--search-bar-bg) border-solid border-3 border-(--button-border) text-(--button-text-color) rounded-full group-hover:opacity-100 transition-opacity duration-200"
         title={`${button.name}を非表示にする`}
         type="button"
       >
@@ -144,7 +144,7 @@ export default function ButtonSettingsArea() {
             }`}>
               <button
                 onClick={() => toggleCategory(categoryIndex)}
-                className="flex items-center justify-center w-[2.7em] h-[2.7em] mr-2 text-base font-bold text-(--button-text-color) bg-(--button-color) rounded-full flex-shrink-0 cursor-pointer border-solid border-2 border-(--search-bar-border-hover)"
+                className="flex items-center justify-center w-[2.7em] h-[2.7em] mr-2 text-base font-bold text-(--button-text-color) bg-(--button-color) rounded-full flex-shrink-0 cursor-pointer border-solid border-3 border-(--button-border)"
                 title={category.name}
               >
                 <span
@@ -179,7 +179,7 @@ export default function ButtonSettingsArea() {
               {hasInactiveButtons && category.isActive && (
                 <button
                   onClick={() => toggleExpanded(categoryIndex)}
-                  className="ml-2 flex items-center justify-center w-[2.7em] h-[2.7em] text-base font-bold text-(--button-text-color) bg-(--button-color) rounded-full flex-shrink-0 border-solid border-2 border-(--search-bar-border-hover) cursor-pointer"
+                  className="ml-2 flex items-center justify-center w-[2.7em] h-[2.7em] text-base font-bold text-(--button-text-color) bg-(--button-color) rounded-full flex-shrink-0 border-solid border-3 border-(--button-border) cursor-pointer"
                   title={isExpanded ? "非表示のボタンを閉じる" : "非表示のボタンを表示"}
                 >
                   {isExpanded ? 
@@ -198,7 +198,7 @@ export default function ButtonSettingsArea() {
                   <button
                     key={button.id}
                     onClick={() => handleToggleButton(button.id)}
-                    className="min-w-18 px-3 py-2 rounded-md whitespace-nowrap cursor-pointer bg-(--button-color) text-(--button-text-color) border-2 border-dashed border-(--search-bar-border-hover) hover:border-solid"
+                    className="min-w-18 px-3 py-2 rounded-md whitespace-nowrap cursor-pointer bg-(--button-color) text-(--button-text-color) border-3 border-dashed border-(--button-border) hover:border-solid"
                     title={`${button.name}を有効にする`}
                   >
                     {button.name}

--- a/src/components/Settings/ButtonSettingsArea.tsx
+++ b/src/components/Settings/ButtonSettingsArea.tsx
@@ -19,6 +19,7 @@ import {
   horizontalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import ResetButton from './ResetButton';
 
 // カテゴリアイコンのマッピング
 const categoryIconMap: Record<string, string> = {
@@ -75,7 +76,7 @@ function SortableButton({ button, category, onToggle }: {
   );
 }
 
-export default function SettingsArea() {
+export default function ButtonSettingsArea() {
   const { categories, loading, toggleCategory, toggleButton, updateButtonOrder } = useSettings();
   const [expandedCategories, setExpandedCategories] = useState<Set<number>>(new Set());
   const [isDeleting, setIsDeleting] = useState(false);
@@ -244,17 +245,7 @@ export default function SettingsArea() {
           </div>
         );
       })}
-      <div className="flex justify-center mt-8">
-        <button
-          onClick={handleDeleteIndexedDB}
-          disabled={isDeleting}
-          className="px-4 py-2 rounded-md cursor-pointer bg-red-500 text-white border-2 border-solid border-red-600 hover:bg-red-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-          title="IndexedDBのデータを削除します"
-        >
-          <span className="icon-[mdi--database-remove] w-5 h-5"></span>
-          {isDeleting ? '削除中...' : 'リセットする'}
-        </button>
-      </div>
+      <ResetButton isDeleting={isDeleting} onDelete={handleDeleteIndexedDB} />
     </div>
   );
 }

--- a/src/components/Settings/ButtonSettingsArea.tsx
+++ b/src/components/Settings/ButtonSettingsArea.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState } from "react";
 import { useSettings } from "contexts/SettingsContext";
-import { useRouter } from "next/navigation";
 import {
   DndContext,
   closestCenter,
@@ -19,7 +18,6 @@ import {
   horizontalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import ResetButton from './ResetButton';
 
 // カテゴリアイコンのマッピング
 const categoryIconMap: Record<string, string> = {
@@ -79,8 +77,6 @@ function SortableButton({ button, category, onToggle }: {
 export default function ButtonSettingsArea() {
   const { categories, loading, toggleCategory, toggleButton, updateButtonOrder } = useSettings();
   const [expandedCategories, setExpandedCategories] = useState<Set<number>>(new Set());
-  const [isDeleting, setIsDeleting] = useState(false);
-  const router = useRouter();
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -143,30 +139,8 @@ export default function ButtonSettingsArea() {
     });
   };
 
-  const handleDeleteIndexedDB = async () => {
-    if (!window.confirm('IndexedDBのデータを削除しますか？この操作は取り消せません。')) {
-      return;
-    }
-
-    setIsDeleting(true);
-    try {
-      const databases = await window.indexedDB.databases();
-      for (const db of databases) {
-        if (db.name) {
-          await window.indexedDB.deleteDatabase(db.name);
-        }
-      }
-      router.replace('/');
-    } catch (error) {
-      console.error('IndexedDBの削除中にエラーが発生しました:', error);
-      alert('データの削除中にエラーが発生しました。');
-    } finally {
-      setIsDeleting(false);
-    }
-  };
-
   return (
-    <div className="flex flex-col justify-center mx-auto my-4 mb-8 max-md:overflow-x-scroll max-md:w-full">
+    <div className="flex flex-col justify-center mx-auto pt-4 pb-12 max-md:overflow-x-scroll max-md:w-full">
       {categories.map((category, categoryIndex) => {
         const inactiveButtons = category.list.filter((button) => !button.isActive);
         const hasInactiveButtons = inactiveButtons.length > 0;
@@ -245,7 +219,6 @@ export default function ButtonSettingsArea() {
           </div>
         );
       })}
-      <ResetButton isDeleting={isDeleting} onDelete={handleDeleteIndexedDB} />
     </div>
   );
 }

--- a/src/components/Settings/ResetButton.tsx
+++ b/src/components/Settings/ResetButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface ResetButtonProps {
+  isDeleting: boolean;
+  onDelete: () => void;
+}
+
+export default function ResetButton({ isDeleting, onDelete }: ResetButtonProps) {
+  return (
+    <div className="flex justify-center mt-8">
+      <button
+        onClick={onDelete}
+        disabled={isDeleting}
+        className="px-4 py-2 rounded-md cursor-pointer bg-red-500 text-white border-2 border-solid border-red-600 hover:bg-red-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+        title="IndexedDBのデータを削除します"
+      >
+        <span className="icon-[mdi--database-remove] w-5 h-5"></span>
+        {isDeleting ? '削除中...' : 'リセットする'}
+      </button>
+    </div>
+  );
+} 

--- a/src/components/Settings/ResetButton.tsx
+++ b/src/components/Settings/ResetButton.tsx
@@ -1,22 +1,45 @@
-import React from 'react';
+"use client";
 
-interface ResetButtonProps {
-  isDeleting: boolean;
-  onDelete: () => void;
-}
+import React, { useState } from 'react';
+import { useRouter } from "next/navigation";
 
-export default function ResetButton({ isDeleting, onDelete }: ResetButtonProps) {
+export default function ResetButton() {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const router = useRouter();
+
+  const handleDeleteIndexedDB = async () => {
+    if (!window.confirm('データを削除しますか？この操作は取り消せません。')) {
+      return;
+    }
+
+    setIsDeleting(true);
+    try {
+      const databases = await window.indexedDB.databases();
+      for (const db of databases) {
+        if (db.name) {
+          await window.indexedDB.deleteDatabase(db.name);
+        }
+      }
+      router.replace('/');
+    } catch (error) {
+      console.error('IndexedDBの削除中にエラーが発生しました:', error);
+      alert('データの削除中にエラーが発生しました。');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
   return (
-    <div className="flex justify-center mt-8">
+    <>
       <button
-        onClick={onDelete}
+        onClick={handleDeleteIndexedDB}
         disabled={isDeleting}
-        className="px-4 py-2 rounded-md cursor-pointer bg-red-500 text-white border-2 border-solid border-red-600 hover:bg-red-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-        title="IndexedDBのデータを削除します"
+        className="px-4 py-2 text-sm font-bold rounded-md cursor-pointer bg-(--button-color) text-red-600 border-2 border-solid border-red-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+        title="データをリセットします"
       >
-        <span className="icon-[mdi--database-remove] w-5 h-5"></span>
+        <span className="icon-[mdi--database-remove] w-4 h-4"></span>
         {isDeleting ? '削除中...' : 'リセットする'}
       </button>
-    </div>
+    </>
   );
 } 

--- a/src/components/Settings/SaveButton.tsx
+++ b/src/components/Settings/SaveButton.tsx
@@ -13,7 +13,7 @@ export default function SaveButton({ className = '' }: SaveButtonProps) {
   return (
     <button
       onClick={handleSave}
-      className={`flex items-center px-4 py-2 bg-(--fisea-blue) text-(--bg-color) text-sm font-bold rounded-full cursor-pointer hover:opacity-80 transition-opacity duration-200 ${className}`}
+      className={`flex items-center px-6 py-3 bg-(--fisea-blue) text-white text-md font-bold rounded-full cursor-pointer hover:opacity-80 transition-opacity duration-200 ${className}`}
     >
       <span className="icon-[mdi--check-bold] mr-1"></span>
       保存

--- a/src/components/Settings/SelectorSettingsArea.tsx
+++ b/src/components/Settings/SelectorSettingsArea.tsx
@@ -4,11 +4,13 @@ import React from 'react';
 import ResetButton from './ResetButton';
 import { useDefaultSearchSettings } from 'hooks/useDefaultSearchSettings';
 import { useButtonList } from 'hooks/useButtonList';
+import { useTabOpenSettings } from 'hooks/useTabOpenSettings';
 import { DomainItem } from 'types';
 
 export default function SelectorSettingsArea() {
-  const { defaultSearch, saveDefaultSearch, isLoading } = useDefaultSearchSettings();
+  const { defaultSearch, saveDefaultSearch, isLoading: isDefaultSearchLoading } = useDefaultSearchSettings();
   const { buttonList } = useButtonList();
+  const { tabOpenType, saveTabOpenType, isLoading: isTabOpenLoading } = useTabOpenSettings();
 
   // カテゴリごとにボタンをグループ化
   const groupedButtons = buttonList.reduce((acc, button) => {
@@ -27,6 +29,10 @@ export default function SelectorSettingsArea() {
     }
   };
 
+  const handleTabOpenChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    saveTabOpenType(event.target.value as 'new' | 'current');
+  };
+
   return (
     <div className="rounded-lg p-4 mx-4 w-full max-w-2xl bg-white border-2 border-solid border-(--search-bar-border)">
       <h2 className="flex items-center mb-4 pb-4 w-full border-b-2 border-solid border-(--search-bar-border)">
@@ -41,7 +47,7 @@ export default function SelectorSettingsArea() {
             value={defaultSearch?.name || ''}
             onChange={handleSearchSiteChange}
             className="border border-(--search-bar-border) rounded px-2 py-1 bg-(--background-color) text-(--text-color)"
-            disabled={isLoading}
+            disabled={isDefaultSearchLoading}
             aria-label="デフォルトの検索サイトを選択"
           >
             <option value="">選択してください</option>
@@ -61,7 +67,16 @@ export default function SelectorSettingsArea() {
       <div className="flex flex-col items-start justify-start w-full mt-6">
         <div className="flex items-center justify-start w-full">
           <h3 className="text-md font-bold mr-4">タブの開き方</h3>
-          <p>ここにセレクトボタンを設置</p>
+          <select
+            value={tabOpenType}
+            onChange={handleTabOpenChange}
+            className="border border-(--search-bar-border) rounded px-2 py-1 bg-(--background-color) text-(--text-color)"
+            disabled={isTabOpenLoading}
+            aria-label="タブの開き方を選択"
+          >
+            <option value="new">新しいタブで開く</option>
+            <option value="current">現在のタブで開く</option>
+          </select>
         </div>
         <p className="text-sm mt-2">新しいタブで開くか、現在のタブで開くかを選択します。</p>
       </div>

--- a/src/components/Settings/SelectorSettingsArea.tsx
+++ b/src/components/Settings/SelectorSettingsArea.tsx
@@ -10,6 +10,16 @@ export default function SelectorSettingsArea() {
   const { defaultSearch, saveDefaultSearch, isLoading } = useDefaultSearchSettings();
   const { buttonList } = useButtonList();
 
+  // カテゴリごとにボタンをグループ化
+  const groupedButtons = buttonList.reduce((acc, button) => {
+    const category = button.category || 'その他';
+    if (!acc[category]) {
+      acc[category] = [];
+    }
+    acc[category].push(button);
+    return acc;
+  }, {} as Record<string, DomainItem[]>);
+
   const handleSearchSiteChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedButton = buttonList.find((button: DomainItem) => button.name === event.target.value);
     if (selectedButton) {
@@ -18,7 +28,7 @@ export default function SelectorSettingsArea() {
   };
 
   return (
-    <div className="rounded-lg p-4 mx-4 w-full max-w-2xl border-2 border-solid border-(--search-bar-border)">
+    <div className="rounded-lg p-4 mx-4 w-full max-w-2xl bg-white border-2 border-solid border-(--search-bar-border)">
       <h2 className="flex items-center mb-4 pb-4 w-full border-b-2 border-solid border-(--search-bar-border)">
         <span className="icon-[mdi--settings-outline] text-(--text-color) mr-1 w-7 h-7"></span>
         <span className="text-lg font-bold">設定</span>
@@ -35,10 +45,14 @@ export default function SelectorSettingsArea() {
             aria-label="デフォルトの検索サイトを選択"
           >
             <option value="">選択してください</option>
-            {buttonList.map((button: DomainItem) => (
-              <option key={button.name} value={button.name}>
-                {button.name}
-              </option>
+            {Object.entries(groupedButtons).map(([category, buttons]) => (
+              <optgroup key={category} label={category}>
+                {buttons.map((button: DomainItem) => (
+                  <option key={button.name} value={button.name}>
+                    {button.name}
+                  </option>
+                ))}
+              </optgroup>
             ))}
           </select>
         </div>

--- a/src/components/Settings/SelectorSettingsArea.tsx
+++ b/src/components/Settings/SelectorSettingsArea.tsx
@@ -2,8 +2,21 @@
 
 import React from 'react';
 import ResetButton from './ResetButton';
+import { useDefaultSearchSettings } from 'hooks/useDefaultSearchSettings';
+import { useButtonList } from 'hooks/useButtonList';
+import { DomainItem } from 'types';
 
 export default function SelectorSettingsArea() {
+  const { defaultSearch, saveDefaultSearch, isLoading } = useDefaultSearchSettings();
+  const { buttonList } = useButtonList();
+
+  const handleSearchSiteChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedButton = buttonList.find((button: DomainItem) => button.name === event.target.value);
+    if (selectedButton) {
+      saveDefaultSearch(selectedButton);
+    }
+  };
+
   return (
     <div className="rounded-lg p-4 mx-4 w-full max-w-2xl border-2 border-solid border-(--search-bar-border)">
       <h2 className="flex items-center mb-4 pb-4 w-full border-b-2 border-solid border-(--search-bar-border)">
@@ -14,7 +27,20 @@ export default function SelectorSettingsArea() {
       <div className="flex flex-col items-start justify-start w-full mt-6">
         <div className="flex items-center justify-start w-full">
           <h3 className="text-md font-bold mr-4">デフォルトの検索サイト</h3>
-          <p>ここにセレクトリストを設置</p>
+          <select
+            value={defaultSearch?.name || ''}
+            onChange={handleSearchSiteChange}
+            className="border border-(--search-bar-border) rounded px-2 py-1 bg-(--background-color) text-(--text-color)"
+            disabled={isLoading}
+            aria-label="デフォルトの検索サイトを選択"
+          >
+            <option value="">選択してください</option>
+            {buttonList.map((button: DomainItem) => (
+              <option key={button.name} value={button.name}>
+                {button.name}
+              </option>
+            ))}
+          </select>
         </div>
         <p className="text-sm mt-2">エンターキーを押したときの検索サイトを変更します。</p>
       </div>

--- a/src/components/Settings/SelectorSettingsArea.tsx
+++ b/src/components/Settings/SelectorSettingsArea.tsx
@@ -10,13 +10,7 @@ export default function SelectorSettingsArea() {
         <span className="icon-[mdi--settings-outline] text-(--text-color) mr-1 w-7 h-7"></span>
         <span className="text-lg font-bold">設定</span>
       </h2>
-      <div className="flex flex-col items-start justify-start w-full mt-4">
-        <div className="flex items-center justify-start w-full">
-          <h3 className="text-md font-bold mr-4">保存データの初期化</h3>
-          <ResetButton />
-        </div>
-        <p className="text-sm mt-2">データの初期化が完了すると、ボタン配置は初期状態にリセットされます。</p>
-      </div>
+
       <div className="flex flex-col items-start justify-start w-full mt-6">
         <div className="flex items-center justify-start w-full">
           <h3 className="text-md font-bold mr-4">デフォルトの検索サイト</h3>
@@ -30,6 +24,13 @@ export default function SelectorSettingsArea() {
           <p>ここにセレクトボタンを設置</p>
         </div>
         <p className="text-sm mt-2">新しいタブで開くか、現在のタブで開くかを選択します。</p>
+      </div>
+      <div className="flex flex-col items-start justify-start w-full mt-4">
+        <div className="flex items-center justify-start w-full">
+          <h3 className="text-md font-bold mr-4">保存データの初期化</h3>
+          <ResetButton />
+        </div>
+        <p className="text-sm mt-2">データの初期化が完了すると、ボタン配置は初期状態にリセットされます。</p>
       </div>
     </div>
   );

--- a/src/components/Settings/SelectorSettingsArea.tsx
+++ b/src/components/Settings/SelectorSettingsArea.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React from 'react';
+import ResetButton from './ResetButton';
+
+export default function SelectorSettingsArea() {
+  return (
+    <div className="rounded-lg p-4 mx-4 w-full max-w-2xl border-2 border-solid border-(--search-bar-border)">
+      <h2 className="flex items-center mb-4 pb-4 w-full border-b-2 border-solid border-(--search-bar-border)">
+        <span className="icon-[mdi--settings-outline] text-(--text-color) mr-1 w-7 h-7"></span>
+        <span className="text-lg font-bold">設定</span>
+      </h2>
+      <div className="flex flex-col items-start justify-start w-full mt-4">
+        <div className="flex items-center justify-start w-full">
+          <h3 className="text-md font-bold mr-4">保存データの初期化</h3>
+          <ResetButton />
+        </div>
+        <p className="text-sm mt-2">データの初期化が完了すると、ボタン配置は初期状態にリセットされます。</p>
+      </div>
+      <div className="flex flex-col items-start justify-start w-full mt-6">
+        <div className="flex items-center justify-start w-full">
+          <h3 className="text-md font-bold mr-4">デフォルトの検索サイト</h3>
+          <p>ここにセレクトリストを設置</p>
+        </div>
+        <p className="text-sm mt-2">エンターキーを押したときの検索サイトを変更します。</p>
+      </div>
+      <div className="flex flex-col items-start justify-start w-full mt-6">
+        <div className="flex items-center justify-start w-full">
+          <h3 className="text-md font-bold mr-4">タブの開き方</h3>
+          <p>ここにセレクトボタンを設置</p>
+        </div>
+        <p className="text-sm mt-2">新しいタブで開くか、現在のタブで開くかを選択します。</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Settings/SelectorSettingsArea.tsx
+++ b/src/components/Settings/SelectorSettingsArea.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from 'react';
+import React, { useState } from 'react';
 import ResetButton from './ResetButton';
 import { useDefaultSearchSettings } from 'hooks/useDefaultSearchSettings';
 import { useButtonList } from 'hooks/useButtonList';
@@ -8,6 +8,7 @@ import { useTabOpenSettings } from 'hooks/useTabOpenSettings';
 import { DomainItem } from 'types';
 
 export default function SelectorSettingsArea() {
+  const [isAdvancedSettingsOpen, setIsAdvancedSettingsOpen] = useState(false);
   const { defaultSearch, saveDefaultSearch, isLoading: isDefaultSearchLoading } = useDefaultSearchSettings();
   const { buttonList } = useButtonList();
   const { tabOpenType, saveTabOpenType, isLoading: isTabOpenLoading } = useTabOpenSettings();
@@ -29,24 +30,25 @@ export default function SelectorSettingsArea() {
     }
   };
 
-  const handleTabOpenChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleTabOpenChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     saveTabOpenType(event.target.value as 'new' | 'current');
   };
 
   return (
-    <div className="rounded-lg p-4 mx-4 w-full max-w-2xl bg-white border-2 border-solid border-(--search-bar-border)">
+    <div className="rounded-lg p-4 mx-4 max-w-xl bg-(--search-bar-bg) border-2 border-solid border-(--search-bar-border)">
       <h2 className="flex items-center mb-4 pb-4 w-full border-b-2 border-solid border-(--search-bar-border)">
         <span className="icon-[mdi--settings-outline] text-(--text-color) mr-1 w-7 h-7"></span>
         <span className="text-lg font-bold">設定</span>
       </h2>
 
-      <div className="flex flex-col items-start justify-start w-full mt-6">
+      <div className="flex flex-col items-start justify-start w-full mt-4">
         <div className="flex items-center justify-start w-full">
           <h3 className="text-md font-bold mr-4">デフォルトの検索サイト</h3>
+        </div>
           <select
             value={defaultSearch?.name || ''}
             onChange={handleSearchSiteChange}
-            className="border border-(--search-bar-border) rounded px-2 py-1 bg-(--background-color) text-(--text-color)"
+            className="border border-(--search-bar-border) rounded-md px-2 py-2 mt-2 bg-(--background-color) text-(--text-color)"
             disabled={isDefaultSearchLoading}
             aria-label="デフォルトの検索サイトを選択"
           >
@@ -61,31 +63,56 @@ export default function SelectorSettingsArea() {
               </optgroup>
             ))}
           </select>
-        </div>
-        <p className="text-sm mt-2">エンターキーを押したときの検索サイトを変更します。</p>
+        <p className="text-sm mt-2">エンターキーを押したときと、矢印ボタンを押したときの検索サイトを選択します。</p>
       </div>
-      <div className="flex flex-col items-start justify-start w-full mt-6">
-        <div className="flex items-center justify-start w-full">
-          <h3 className="text-md font-bold mr-4">タブの開き方</h3>
-          <select
-            value={tabOpenType}
-            onChange={handleTabOpenChange}
-            className="border border-(--search-bar-border) rounded px-2 py-1 bg-(--background-color) text-(--text-color)"
-            disabled={isTabOpenLoading}
-            aria-label="タブの開き方を選択"
-          >
-            <option value="new">新しいタブで開く</option>
-            <option value="current">現在のタブで開く</option>
-          </select>
+      <div className="flex flex-col items-start justify-start mt-6">
+        <div className="flex flex-col items-start justify-start w-full">
+          <h3 className="text-md font-bold mb-2">タブの開き方</h3>
+          <div className="flex flex-wrap gap-2">
+            <label className="flex items-center cursor-pointer">
+              <input
+                type="radio"
+                value="new"
+                checked={tabOpenType === 'new'}
+                onChange={handleTabOpenChange}
+                className="mr-2"
+                disabled={isTabOpenLoading}
+              />
+              <span>新しいタブで開く</span>
+            </label>
+            <label className="flex items-center cursor-pointer">
+              <input
+                type="radio"
+                value="current"
+                checked={tabOpenType === 'current'}
+                onChange={handleTabOpenChange}
+                className="mr-2"
+                disabled={isTabOpenLoading}
+              />
+              <span>現在のタブで開く</span>
+            </label>
+          </div>
         </div>
         <p className="text-sm mt-2">新しいタブで開くか、現在のタブで開くかを選択します。</p>
       </div>
-      <div className="flex flex-col items-start justify-start w-full mt-4">
-        <div className="flex items-center justify-start w-full">
-          <h3 className="text-md font-bold mr-4">保存データの初期化</h3>
-          <ResetButton />
-        </div>
-        <p className="text-sm mt-2">データの初期化が完了すると、ボタン配置は初期状態にリセットされます。</p>
+      <div className="flex flex-col items-start justify-start w-full mt-4 p-4 rounded-md border-2 border-(--search-bar-border)">
+        <button
+          onClick={() => setIsAdvancedSettingsOpen(!isAdvancedSettingsOpen)}
+          className="flex items-center justify-start w-full text-left cursor-pointer"
+          type="button"
+        >
+          {isAdvancedSettingsOpen ? 
+            <span className={`icon-[mdi--chevron-up] text-(--text-color) w-5 h-5`}></span>
+          : <span className={`icon-[mdi--chevron-down] text-(--text-color) w-5 h-5`}></span>}
+          <h3 className="text-md font-bold ml-2">高度な設定</h3>
+        </button>
+        {isAdvancedSettingsOpen && (
+          <div className="w-full mt-4">
+            <h3 className="text-md font-bold mb-2">保存データのリセット</h3>
+            <ResetButton />
+            <p className="text-sm mt-2">データのリセットが完了すると、ボタン配置と検索設定は初期状態に戻ります。</p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/Settings/SettingsArea.tsx
+++ b/src/components/Settings/SettingsArea.tsx
@@ -55,7 +55,7 @@ function SortableButton({ button, category, onToggle }: {
   };
 
   return (
-    <div ref={setNodeRef} style={style} className="relative group">
+    <div ref={setNodeRef} style={style} className="relative group touch-none">
       <div {...attributes} {...listeners} className="cursor-move">
         <button
           className="select-none min-w-18 px-3 py-2 rounded-md whitespace-nowrap bg-(--button-color) text-(--button-text-color) border-2 border-solid border-(--search-bar-border-hover)"
@@ -173,7 +173,7 @@ export default function SettingsArea() {
 
         return (
           <div key={categoryIndex} className="flex flex-col">
-            <div className={`flex items-start mt-3 max-md:ml-5 ${
+            <div className={`flex items-start mt-4 max-md:ml-5 ${
               !category.isActive && "opacity-50"
             }`}>
               <button
@@ -232,7 +232,7 @@ export default function SettingsArea() {
                   <button
                     key={button.id}
                     onClick={() => handleToggleButton(button.id)}
-                    className="px-3 py-2 rounded-md whitespace-nowrap cursor-pointer bg-(--button-color) text-(--button-text-color) border-2 border-dashed border-(--search-bar-border-hover) hover:border-solid"
+                    className="min-w-18 px-3 py-2 rounded-md whitespace-nowrap cursor-pointer bg-(--button-color) text-(--button-text-color) border-2 border-dashed border-(--search-bar-border-hover) hover:border-solid"
                     title={`${button.name}を有効にする`}
                   >
                     {button.name}

--- a/src/components/Settings/SettingsArea.tsx
+++ b/src/components/Settings/SettingsArea.tsx
@@ -3,6 +3,22 @@
 import React, { useState } from "react";
 import { useSettings } from "contexts/SettingsContext";
 import { useRouter } from "next/navigation";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  horizontalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 // カテゴリアイコンのマッピング
 const categoryIconMap: Record<string, string> = {
@@ -14,11 +30,99 @@ const categoryIconMap: Record<string, string> = {
   Other: "icon-[mdi--folder]",
 };
 
+// ソート可能なボタンコンポーネント
+function SortableButton({ button, category, onToggle }: { 
+  button: { id: string; name: string; isActive: boolean }; 
+  category: { isActive: boolean };
+  onToggle: (id: string) => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({ id: button.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const handleCloseClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onToggle(button.id);
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className="relative group">
+      <div {...attributes} {...listeners} className="cursor-move">
+        <button
+          className="select-none min-w-18 px-3 py-2 rounded-md whitespace-nowrap bg-(--button-color) text-(--button-text-color) border-2 border-solid border-(--search-bar-border-hover)"
+          disabled={!category.isActive}
+        >
+          {button.name}
+        </button>
+      </div>
+      <button
+        onClick={handleCloseClick}
+        className="absolute cursor-pointer -top-2 -right-2 w-5 h-5 flex items-center justify-center bg-(--search-bar-bg) border-solid border-2 border-(--search-bar-border-hover) text-(--button-text-color) rounded-full group-hover:opacity-100 transition-opacity duration-200"
+        title={`${button.name}を無効にする`}
+      >
+        <span className="icon-[mdi--close] w-3 h-3"></span>
+      </button>
+    </div>
+  );
+}
+
 export default function SettingsArea() {
-  const { categories, loading, toggleCategory, toggleButton } = useSettings();
+  const { categories, loading, toggleCategory, toggleButton, updateButtonOrder } = useSettings();
   const [expandedCategories, setExpandedCategories] = useState<Set<number>>(new Set());
   const [isDeleting, setIsDeleting] = useState(false);
   const router = useRouter();
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    
+    if (over && active.id !== over.id) {
+      const activeCategoryIndex = categories.findIndex(category => 
+        category.list.some(button => button.id === active.id)
+      );
+      
+      if (activeCategoryIndex !== -1) {
+        const oldIndex = categories[activeCategoryIndex].list.findIndex(
+          button => button.id === active.id
+        );
+        const newIndex = categories[activeCategoryIndex].list.findIndex(
+          button => button.id === over.id
+        );
+        
+        updateButtonOrder(activeCategoryIndex, oldIndex, newIndex);
+      }
+    }
+  };
+
+  const handleToggleButton = (buttonId: string) => {
+    toggleButton(buttonId);
+    // ボタンが無効化された場合、該当するカテゴリを展開状態にする
+    const categoryIndex = categories.findIndex(category =>
+      category.list.some(button => button.id === buttonId)
+    );
+    if (categoryIndex !== -1) {
+      setExpandedCategories(prev => {
+        const newSet = new Set(prev);
+        newSet.add(categoryIndex);
+        return newSet;
+      });
+    }
+  };
 
   if (loading) {
     return (
@@ -83,27 +187,29 @@ export default function SettingsArea() {
                   } w-5 h-5`}
                 ></span>
               </button>
-              <div className="flex align-center gap-2">
-                {category.list
-                  .filter((button) => button.isActive)
-                  .map((button) => (
-                    <div key={button.id} className="relative group">
-                      <button
-                        className="min-w-18 px-3 py-2 rounded-md whitespace-nowrap bg-(--button-color) text-(--button-text-color) border-2 border-solid border-(--search-bar-border-hover)"
-                        disabled={!category.isActive}
-                      >
-                        {button.name}
-                      </button>
-                      <button
-                        onClick={() => toggleButton(button.id)}
-                        className="absolute cursor-pointer -top-2 -right-2 w-5 h-5 flex items-center justify-center bg-(--search-bar-bg) border-solid border-2 border-(--search-bar-border-hover) text-(--button-text-color) rounded-full group-hover:opacity-100 transition-opacity duration-200"
-                        title={`${button.name}を無効にする`}
-                      >
-                        <span className="icon-[mdi--close] w-3 h-3"></span>
-                      </button>
-                    </div>
-                  ))}
-              </div>
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <div className="flex align-center gap-2">
+                  <SortableContext
+                    items={category.list.filter(button => button.isActive).map(button => button.id)}
+                    strategy={horizontalListSortingStrategy}
+                  >
+                    {category.list
+                      .filter((button) => button.isActive)
+                      .map((button) => (
+                        <SortableButton
+                          key={button.id}
+                          button={button}
+                          category={category}
+                          onToggle={handleToggleButton}
+                        />
+                      ))}
+                  </SortableContext>
+                </div>
+              </DndContext>
               {hasInactiveButtons && category.isActive && (
                 <button
                   onClick={() => toggleExpanded(categoryIndex)}
@@ -117,20 +223,22 @@ export default function SettingsArea() {
               )}
             </div>
             {isExpanded && hasInactiveButtons && category.isActive && (
-              <div className="flex flex-wrap max-md:flex-nowrap rounded-md max-w-xl w-full gap-2 mt-2 max-md:ml-5">
+              <div className="flex flex-nowrap max-md:flex-nowrap rounded-md max-w-xl w-full gap-2 mt-2 max-md:ml-5">
                 <div className="flex justify-center items-center w-[2.7em] h-[2.7em] text-base font-bold text-(--button-text-color) rounded-full flex-shrink-0">
                   <span className="icon-[mdi--favorite-add-outline] w-6 h-6"></span>
                 </div>
+                <div className="flex flex-wrap align-center gap-2">
                 {inactiveButtons.map((button) => (
                   <button
                     key={button.id}
-                    onClick={() => toggleButton(button.id)}
+                    onClick={() => handleToggleButton(button.id)}
                     className="px-3 py-2 rounded-md whitespace-nowrap cursor-pointer bg-(--button-color) text-(--button-text-color) border-2 border-dashed border-(--search-bar-border-hover) hover:border-solid"
                     title={`${button.name}を有効にする`}
                   >
                     {button.name}
                   </button>
                 ))}
+                </div>
               </div>
             )}
           </div>

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -12,6 +12,7 @@ interface SettingsContextType {
   toggleCategory: (categoryIndex: number) => void;
   toggleButton: (buttonId: string) => void;
   handleSave: () => Promise<void>;
+  updateButtonOrder: (categoryIndex: number, oldIndex: number, newIndex: number) => void;
 }
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
@@ -118,13 +119,27 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     }
   };
 
+  const updateButtonOrder = (categoryIndex: number, oldIndex: number, newIndex: number) => {
+    setCategories(prevCategories => {
+      const newCategories = [...prevCategories];
+      const category = { ...newCategories[categoryIndex] };
+      const newList = [...category.list];
+      const [movedItem] = newList.splice(oldIndex, 1);
+      newList.splice(newIndex, 0, movedItem);
+      category.list = newList;
+      newCategories[categoryIndex] = category;
+      return newCategories;
+    });
+  };
+
   return (
     <SettingsContext.Provider value={{
       categories,
       loading,
       toggleCategory,
       toggleButton,
-      handleSave
+      handleSave,
+      updateButtonOrder
     }}>
       {children}
     </SettingsContext.Provider>

--- a/src/hooks/useButtonList.ts
+++ b/src/hooks/useButtonList.ts
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react';
+import { DomainItem } from 'types';
+import domainList from 'components/ButtonArea/ButtonComponents/domainList.json';
+import { useSettings } from 'contexts/SettingsContext';
+
+export const useButtonList = () => {
+  const { categories } = useSettings();
+  const [buttonList, setButtonList] = useState<DomainItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const activeButtons = categories
+      .filter(category => category.isActive)
+      .flatMap(category => 
+        category.list
+          .filter(button => button.isActive)
+          .map(button => {
+            const domainItem = (domainList as DomainItem[]).find(
+              item => item.name === button.name
+            );
+            return domainItem;
+          })
+          .filter((item): item is DomainItem => item !== undefined)
+      );
+
+    setButtonList(activeButtons);
+    setIsLoading(false);
+  }, [categories]);
+
+  return { buttonList, isLoading };
+}; 

--- a/src/hooks/useDefaultSearchSettings.ts
+++ b/src/hooks/useDefaultSearchSettings.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react';
+import { DomainItem } from 'types';
+import { openDB } from 'utils/indexedDB';
+
+const STORE_NAME = 'defaultSearch';
+const KEY = 'default-search-settings';
+
+export const useDefaultSearchSettings = () => {
+  const [defaultSearch, setDefaultSearch] = useState<DomainItem | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const initDB = async () => {
+      try {
+        const db = await openDB();
+        const transaction = db.transaction(STORE_NAME, 'readonly');
+        const store = transaction.objectStore(STORE_NAME);
+        const getRequest = store.get(KEY);
+
+        getRequest.onsuccess = () => {
+          setDefaultSearch(getRequest.result || null);
+          setIsLoading(false);
+        };
+
+        getRequest.onerror = () => {
+          console.error('設定の読み込みに失敗しました');
+          setIsLoading(false);
+        };
+      } catch (error) {
+        console.error('IndexedDBの初期化に失敗しました:', error);
+        setIsLoading(false);
+      }
+    };
+
+    initDB();
+  }, []);
+
+  const saveDefaultSearch = async (search: DomainItem) => {
+    try {
+      const db = await openDB();
+      const transaction = db.transaction(STORE_NAME, 'readwrite');
+      const store = transaction.objectStore(STORE_NAME);
+      store.put(search, KEY);
+      setDefaultSearch(search);
+    } catch (error) {
+      console.error('設定の保存に失敗しました:', error);
+    }
+  };
+
+  return { defaultSearch, saveDefaultSearch, isLoading };
+}; 

--- a/src/hooks/useTabOpenSettings.ts
+++ b/src/hooks/useTabOpenSettings.ts
@@ -1,0 +1,62 @@
+import { useState, useEffect } from 'react';
+import { openDB } from 'utils/indexedDB';
+
+const TAB_OPEN_KEY = 'tabOpenType';
+
+type TabOpenType = 'new' | 'current';
+
+export const useTabOpenSettings = () => {
+  const [tabOpenType, setTabOpenType] = useState<TabOpenType>('new');
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      try {
+        const db = await openDB();
+        const transaction = db.transaction('settings', 'readonly');
+        const store = transaction.objectStore('settings');
+        const request = store.get(TAB_OPEN_KEY);
+
+        request.onerror = () => {
+          console.error('設定の読み込みに失敗しました:', request.error);
+          setIsLoading(false);
+        };
+
+        request.onsuccess = () => {
+          const savedType = request.result;
+          if (savedType) {
+            setTabOpenType(savedType);
+          }
+          setIsLoading(false);
+        };
+      } catch (error) {
+        console.error('設定の読み込みに失敗しました:', error);
+        setIsLoading(false);
+      }
+    };
+
+    loadSettings();
+  }, []);
+
+  const saveTabOpenType = async (type: TabOpenType) => {
+    try {
+      const db = await openDB();
+      const transaction = db.transaction('settings', 'readwrite');
+      const store = transaction.objectStore('settings');
+      
+      store.put(type, TAB_OPEN_KEY);
+      
+      return new Promise<void>((resolve, reject) => {
+        transaction.oncomplete = () => {
+          setTabOpenType(type);
+          resolve();
+        };
+        transaction.onerror = () => reject(transaction.error);
+      });
+    } catch (error) {
+      console.error('設定の保存に失敗しました:', error);
+    }
+  };
+
+  return { tabOpenType, saveTabOpenType, isLoading };
+}; 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,7 @@ export interface DomainItem {
   queryBefore?: string;
   queryAfter?: string;
   queryAlt?: string;
+  category?: string;
 }
 
 export interface ButtonItem {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,8 +17,8 @@ export interface ClearButtonProps {
 }
 
 export interface DomainItem {
-  name: string;
   type: number;
+  name: string;
   domain: string;
   subDomain?: string;
   directory?: string;

--- a/src/utils/indexedDB.ts
+++ b/src/utils/indexedDB.ts
@@ -1,9 +1,10 @@
 import { CategoryItem, DomainItem } from 'types';
 
 const DB_NAME = 'fiseaDB';
-const DB_VERSION = 2;
+const DB_VERSION = 1;
 const BUTTON_STORE = 'buttonData';
 const DEFAULT_SEARCH_STORE = 'defaultSearch';
+const SETTINGS_STORE = 'settings';
 
 // IndexedDBへの接続を開く
 export const openDB = (): Promise<IDBDatabase> => {
@@ -23,10 +24,14 @@ export const openDB = (): Promise<IDBDatabase> => {
       if (db.objectStoreNames.contains(DEFAULT_SEARCH_STORE)) {
         db.deleteObjectStore(DEFAULT_SEARCH_STORE);
       }
+      if (db.objectStoreNames.contains(SETTINGS_STORE)) {
+        db.deleteObjectStore(SETTINGS_STORE);
+      }
       
       // ストアを新規作成
       db.createObjectStore(BUTTON_STORE, { keyPath: 'name' });
       db.createObjectStore(DEFAULT_SEARCH_STORE);
+      db.createObjectStore(SETTINGS_STORE);
     };
   });
 };

--- a/src/utils/indexedDB.ts
+++ b/src/utils/indexedDB.ts
@@ -1,10 +1,14 @@
 import { CategoryItem, DomainItem } from 'types';
 
 const DB_NAME = 'fiseaDB';
-const DB_VERSION = 1;
+const DB_VERSION = 2; // バージョンを上げて、ストアの変更をトリガー
 const BUTTON_STORE = 'buttonData';
-const DEFAULT_SEARCH_STORE = 'defaultSearch';
-const SETTINGS_STORE = 'settings';
+const SETTINGS_STORE = 'settingsData';
+
+type SettingsData = {
+  defaultSearch?: DomainItem;
+  tabOpenType?: 'new' | 'current';
+};
 
 // IndexedDBへの接続を開く
 export const openDB = (): Promise<IDBDatabase> => {
@@ -21,16 +25,12 @@ export const openDB = (): Promise<IDBDatabase> => {
       if (db.objectStoreNames.contains(BUTTON_STORE)) {
         db.deleteObjectStore(BUTTON_STORE);
       }
-      if (db.objectStoreNames.contains(DEFAULT_SEARCH_STORE)) {
-        db.deleteObjectStore(DEFAULT_SEARCH_STORE);
-      }
       if (db.objectStoreNames.contains(SETTINGS_STORE)) {
         db.deleteObjectStore(SETTINGS_STORE);
       }
       
       // ストアを新規作成
       db.createObjectStore(BUTTON_STORE, { keyPath: 'name' });
-      db.createObjectStore(DEFAULT_SEARCH_STORE);
       db.createObjectStore(SETTINGS_STORE);
     };
   });
@@ -65,29 +65,46 @@ export const saveButtonData = async (data: CategoryItem[]): Promise<void> => {
   });
 };
 
-// デフォルト検索サイトの設定を取得
-export const getDefaultSearch = async (): Promise<DomainItem | null> => {
+// 設定データを取得
+export const getSettingsData = async (): Promise<SettingsData> => {
   const db = await openDB();
   return new Promise((resolve, reject) => {
-    const transaction = db.transaction(DEFAULT_SEARCH_STORE, 'readonly');
-    const store = transaction.objectStore(DEFAULT_SEARCH_STORE);
-    const request = store.get('default-search-settings');
+    const transaction = db.transaction(SETTINGS_STORE, 'readonly');
+    const store = transaction.objectStore(SETTINGS_STORE);
+    const request = store.get('settings');
     
     request.onerror = () => reject(request.error);
-    request.onsuccess = () => resolve(request.result || null);
+    request.onsuccess = () => resolve(request.result || {});
   });
 };
 
-// デフォルト検索サイトの設定を保存
-export const saveDefaultSearch = async (data: DomainItem): Promise<void> => {
+// 設定データを保存
+export const saveSettingsData = async (data: Partial<SettingsData>): Promise<void> => {
   const db = await openDB();
-  const transaction = db.transaction(DEFAULT_SEARCH_STORE, 'readwrite');
-  const store = transaction.objectStore(DEFAULT_SEARCH_STORE);
-  
-  store.put(data, 'default-search-settings');
-  
   return new Promise((resolve, reject) => {
-    transaction.oncomplete = () => resolve();
+    const transaction = db.transaction(SETTINGS_STORE, 'readwrite');
+    const store = transaction.objectStore(SETTINGS_STORE);
+    
+    // 既存の設定を取得
+    const getRequest = store.get('settings');
+    
+    getRequest.onsuccess = () => {
+      // 新しい設定と既存の設定をマージ
+      const existingSettings = getRequest.result || {};
+      const updatedSettings = {
+        ...existingSettings,
+        ...data
+      };
+      
+      // 更新された設定を保存
+      const putRequest = store.put(updatedSettings, 'settings');
+      
+      putRequest.onsuccess = () => resolve();
+      putRequest.onerror = () => reject(putRequest.error);
+    };
+    
+    getRequest.onerror = () => reject(getRequest.error);
+    
     transaction.onerror = () => reject(transaction.error);
   });
 };

--- a/src/utils/searchUrlGenerator.ts
+++ b/src/utils/searchUrlGenerator.ts
@@ -1,0 +1,62 @@
+import { DomainItem } from 'types';
+
+export const generateSearchUrl = (searchWord: string, domainItem: DomainItem): string => {
+  const wordInputEncoded = encodeURIComponent(
+    searchWord.replace(/^[\p{C}\p{Z}]+|[\p{C}\p{Z}]+$/gu, "")
+  );
+  const wordInputEncodedHash = encodeURIComponent(
+    searchWord.replace(/^#+|[\p{C}\p{Z}]/gu, "")
+  );
+  const wordInputEncodedAt = encodeURIComponent(
+    searchWord.replace(/^@+|[\p{C}\p{Z}]/gu, "")
+  );
+
+  switch (domainItem.type) {
+    case 1:
+      return searchWord
+        ? `https://${domainItem.domain}${domainItem.queryBefore}${wordInputEncoded}`
+        : `https://${domainItem.domain}`;
+    case 2:
+      return searchWord
+        ? `https://${domainItem.domain}${domainItem.queryBefore}${wordInputEncoded}${domainItem.queryAfter}`
+        : `https://${domainItem.domain}${domainItem.directory}`;
+    case 3:
+      return searchWord
+        ? `https://${domainItem.domain}${domainItem.directory}${domainItem.queryBefore}${wordInputEncoded}${domainItem.queryAfter}`
+        : `https://${domainItem.domain}${domainItem.directory}`;
+    case 4:
+      return searchWord
+        ? `https://${domainItem.subDomain}${domainItem.domain}${domainItem.queryBefore}${wordInputEncoded}`
+        : `https://${domainItem.domain}`;
+    case 5:
+      return searchWord
+        ? `https://${domainItem.domain}${domainItem.queryBefore}${wordInputEncoded}${domainItem.queryAfter}`
+        : `https://${domainItem.domain}`;
+    case 6:
+      if (searchWord.match(/^#/)) {
+        return `https://${domainItem.domain}${domainItem.queryAlt}${wordInputEncodedHash}`;
+      } else if (searchWord.match(/^@/)) {
+        return `https://${domainItem.domain}${wordInputEncodedAt}`;
+      } else if (searchWord) {
+        return `https://${domainItem.domain}${domainItem.queryBefore}${wordInputEncoded}`;
+      }
+      return `https://${domainItem.domain}`;
+    case 7:
+      if (searchWord.match(/^#/)) {
+        return `https://${domainItem.domain}${domainItem.queryBefore}${wordInputEncodedHash}`;
+      } else if (searchWord.match(/^@/)) {
+        return `https://${domainItem.domain}${domainItem.queryAlt}${wordInputEncodedAt}`;
+      } else if (searchWord) {
+        return `https://${domainItem.domain}${domainItem.queryBefore}${wordInputEncoded}${domainItem.queryAfter}`;
+      }
+      return `https://${domainItem.domain}`;
+    default:
+      // デフォルトはGoogle検索
+      const encodedQuery = encodeURIComponent(
+        searchWord.replace(/^[\p{C}\p{Z}]+|[\p{C}\p{Z}]+$/gu, "")
+      );
+      return searchWord
+        ? `https://www.google.co.jp/search?q=${encodedQuery}`
+        : "https://www.google.co.jp/";
+  }
+}; 


### PR DESCRIPTION
## ボタンの並び替え対応
- ボタンをドラッグ・アンド・ドロップで並び替え可能に
- スマホ用にボタンエリアの上下にスクロールしやすいpaddingを追加

## 検索設定画面
- データベースのリセットボタン
- デフォルトの検索サイトの設定
- 新しいタブか現在のタブで開くかの選択

## その他の変更
- データベースバージョンアップ(1->2)
- UIの細かい修正